### PR TITLE
Add ThermalHealthDetailsDell and ThermalSensorDetailsDell structs and GetThermalHealthDell function

### DIFF
--- a/types.go
+++ b/types.go
@@ -4277,3 +4277,58 @@ type StorageRaidDetailsDell struct {
 	StripeSize       string `json:"StripeSize"`
 	WriteCachePolicy string `json:"WriteCachePolicy"`
 }
+
+// ThermalSensorDetailsDell ... Struct for thermal sensor details
+type ThermalSensorDetailsDell struct {
+	OdataContext string `json:"@odata.context"`
+	OdataID      string `json:"@odata.id"`
+	OdataType    string `json:"@odata.type"`
+	Name         string `json:"Name"`
+	Id           string `json:"Id"`
+	Description  string `json:"Description"`
+	ReadingType  string `json:"ReadingType"`
+	ReadingUnits string `json:"ReadingUnits"`
+
+	Status struct {
+		Health string `json:"Health"`
+		State  string `json:"State"`
+	} `json:"Status"`
+	Reading         float64 `json:"Reading"`
+	PhysicalContext string  `json:"PhysicalContext"`
+	Oem             struct {
+		Dell struct {
+			OdataType      string   `json:"@odata.type"`
+			CurrentState   string   `json:"CurrentState"`
+			DeviceID       string   `json:"DeviceID"`
+			PossibleStates []string `json:"PossibleStates"`
+			RequestedState string   `json:"RequestedState"`
+		} `json:"Dell"`
+	} `json:"Oem"`
+
+	Thresholds struct {
+		UpperCritical struct {
+			Reading int `json:"Reading"`
+		} `json:"UpperCritical"`
+		UpperCaution struct {
+			Reading interface{} `json:"Reading"`
+		} `json:"UpperCaution"`
+		LowerCaution struct {
+			Reading interface{} `json:"Reading"`
+		} `json:"LowerCaution"`
+		LowerCritical struct {
+			Reading int `json:"Reading"`
+		} `json:"LowerCritical"`
+	} `json:"Thresholds"`
+}
+
+// ThermalHealthDetailsDell ... Struct for thermal health details
+type ThermalHealthDetailsDell struct {
+	Name          string      `json:"Name"`
+	Reading       float64     `json:"Reading"`
+	State         string      `json:"State"`
+	Health        string      `json:"Health"`
+	UpperCritical int         `json:"UpperCritical"`
+	UpperCaution  interface{} `json:"UpperCaution"`
+	LowerCaution  interface{} `json:"LowerCaution"`
+	LowerCritical int         `json:"LowerCritical"`
+}


### PR DESCRIPTION
### Summary
This PR introduces the following additions:
1. **`ThermalHealthDetailsDell` Struct**: Added to `types.go` to represent thermal health data, including critical thresholds and sensor states.
2. **`ThermalSensorDetailsDell` Struct**: Added to `types.go` to encapsulate detailed sensor information, including reading types, physical context, and thresholds.
3. **`GetThermalHealthDell` Function**: Added to `dell.go` to fetch and process thermal health details using the Redfish API.

### Changes
- **`types.go`**:
  - Added `ThermalHealthDetailsDell`.
  - Added `ThermalSensorDetailsDell`.

- **`dell.go`**:
  - Implemented `GetThermalHealthDell` function to retrieve thermal data for Dell systems.

### Why is this needed?
These enhancements provide comprehensive support for monitoring thermal health and sensor details of Dell systems through the Redfish API, enabling better diagnostics and management.
